### PR TITLE
Upgrade to Version 1.8 (Solr 5.4+ support, PEP8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ pip-log.txt
 
 #Mr Developer
 .mr.developer.cfg
+
+venv/

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,7 +1,7 @@
 Licensed under the terms of the Modified BSD License (also known as
 New or Revised BSD)
 
-Copyright (c) 2013, Didier Deshommes
+Copyright (c) 2013-2016, Didier Deshommes, Robert Elwell
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -30,7 +30,7 @@ OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #-----------------------------------------------------------------------------
-# Copyright (c) 2013, Didier Deshommes.
+# Copyright (c) 2013-2016, Didier Deshommes, Robert Elwell.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,3 @@
-**NOTE: This project needs a new maintainer. To volunteer, please send me a note at my github email address**
-
 solrcloudpy
 ===========
 
@@ -11,10 +9,14 @@ library aims to take advantage of the following features of Solr:
 * Centralized index management
 * Near-realtime search
 
-It is meant to be compatible with solr versions *4.6* to *5.0*.
+It is compatible with versions 4.6 up to 5.5.
 The API is meant to be close to pymongo's API, where one can access
 collections and databases as simple attributes 
-or dictionary keys.  
+or dictionary keys.
+
+As of 2016, this library is maintained by the Solrcloudpy community.
+Contributions are welcome.
+
 
 Usage
 -------

--- a/README.rst
+++ b/README.rst
@@ -49,8 +49,8 @@ Search documents:
 Console
 -------
 ``solrcloudpy`` comes with a console that can be run simply by typing ``solrconsole``. More information on usage is available at
-http://dfdeshom.github.io/solrcloudpy/console.html
+http://solrcloudpy.github.io/solrcloudpy/console.html
 
 Documentation and API
 ---------------------
-Documentation can be found at http://dfdeshom.github.io/solrcloudpy/
+Documentation can be found at http://solrcloudpy.github.io/solrcloudpy/

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,7 @@
+# Code of Conduct
+
+Solrcloudpy is an open organization interested in the 
+feedback and involvement of individuals of all backgrounds
+and levels of experience.
+
+In the words of Bill and Ted, be excellent to each other.

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -37,7 +37,7 @@ Installation
 install the development version:
 
 ``pip install
-git+https://github.com/dfdeshom/solrcloudpy.git#egg=solrcloudpy``
+git+https://github.com/solrcloudpy/solrcloudpy.git#egg=solrcloudpy``
 
 
 Contributing

--- a/setup.py
+++ b/setup.py
@@ -4,27 +4,26 @@ import re
 with open('README.rst', 'r') as f:
     long_description = f.read()
 
+
 def get_version():
-    return re.search(r"""__version__\s+=\s+(?P<quote>['"])(?P<version>.+?)(?P=quote)""", open('solrcloudpy/__init__.py').read()).group('version')
+    return re.search(r"""__version__\s+=\s+(?P<quote>['"])(?P<version>.+?)(?P=quote)""", 
+                     open('solrcloudpy/__init__.py').read()).group('version')
 
 setup(
-    name = "solrcloudpy",
-    version = get_version(),
-    author = 'Didier Deshommes',
-    author_email = 'dfdeshom@gmail.com',
+    name="solrcloudpy",
+    version=get_version(),
+    author='Didier Deshommes, Robert Elwell',
+    author_email='dfdeshom@gmail.com, robert.elwell@gmail.com',
     packages=find_packages(exclude=['ez_setup']),
-    url='https://github.com/dfdeshom/solrcloudpy',
+    url='https://github.com/solrcloudpy/solrcloudpy',
     license='LICENSE.txt',
     keywords='solr solrcloud',
     description='python library for interacting with SolrCloud ',
     long_description=long_description,
     include_package_data=True,
     platforms='any',
-    entry_points = {
-        'console_scripts': [
-        'solrconsole = scripts.solrconsole:main [ip]']
-        },
-    classifiers = [
+    entry_points={'console_scripts': ['solrconsole = scripts.solrconsole:main [ip]']},
+    classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
@@ -33,6 +32,6 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Indexing/Search'
         ],
 
-    install_requires = ['requests >= 2.2.1','IPython >= 1.2.0'],
-    extras_require = {"ip": ['IPython >= 1.2.0'] },
-        )
+    install_requires=['requests >= 2.2.1', 'IPython >= 1.2.0'],
+    extras_require={"ip": ['IPython >= 1.2.0']}
+)

--- a/solrcloudpy/__init__.py
+++ b/solrcloudpy/__init__.py
@@ -4,5 +4,5 @@ from solrcloudpy.parameters import SearchOptions
 import logging
 logging.basicConfig()
 
-__version__ = "1.7.460"
+__version__ = "1.8.0"
 __all__ = ['SolrCollection', 'SolrConnection', 'SearchOptions']

--- a/solrcloudpy/collection/__init__.py
+++ b/solrcloudpy/collection/__init__.py
@@ -25,7 +25,7 @@ Support will be coming for the following endpoints:
 
      >>> from solrcloudpy import SolrConnection
      >>> coll = SolrConnection()['collection1']
-     >>> response = coll.search({'q':'money'})
+     >>> response = coll.search({'q': 'money'})
      >>> response
      <SolrResponse [200]>
      >>> response.result
@@ -37,18 +37,20 @@ Support will be coming for the following endpoints:
 from .admin import SolrCollectionAdmin
 from .search import SolrCollectionSearch
 
-class SolrCollection(SolrCollectionAdmin,SolrCollectionSearch):
+
+class SolrCollection(SolrCollectionAdmin, SolrCollectionSearch):
     def create(self, replication_factor=1, force=False, **kwargs):
         """
         Create a collection
 
-        :param num_shards: an integer indicating the number of shards for this collection
-
         :param replication_factor: an integer indicating the number of replcas for this collection
+        :type replication_factor: int
 
         :param force: a boolean value indicating whether to force the operation
+        :type force: bool
 
         :param kwargs: additional parameters to be passed to this operation
+        
 
         :Additional Parameters:
           - `router_name`: router name that will be used. defines how documents will be distributed among the shards
@@ -62,9 +64,8 @@ class SolrCollection(SolrCollectionAdmin,SolrCollectionSearch):
         Additional parameters are further documented at https://cwiki.apache.org/confluence/display/solr/Collections+API#CollectionsAPI-CreateaCollection
         """
 
-        admin = super(SolrCollection,self).create(replication_factor,
-                                              force, **kwargs)
-        return SolrCollection(admin.connection,admin.name)
+        admin = super(SolrCollection, self).create(replication_factor, force, **kwargs)
+        return SolrCollection(admin.connection, admin.name)
 
     def __repr__(self):
         return "SolrCollection<%s>" % self.name

--- a/solrcloudpy/collection/admin.py
+++ b/solrcloudpy/collection/admin.py
@@ -9,21 +9,29 @@ import time
 import json
 import requests
 
+
 class SolrCollectionAdmin(CollectionBase):
     """
     Manage and administer a collection
     """
-    def __init__(self,connection,name):
-        super(SolrCollectionAdmin,self).__init__(connection,name)
-        self.index_stats = SolrIndexStats(self.connection,self.name)
-        self.schema = SolrSchema(self.connection,self.name)
+    def __init__(self, connection, name):
+        """
+        :param connection: the connection to Solr
+        :type connection: SolrConnection
+        :param name: the name of the collection
+        :type name: str
+        """
+        super(SolrCollectionAdmin, self).__init__(connection, name)
+        
+        # corresponding public methods are memoized for a lower memory footprint
+        self._index_stats = None
+        self._schema = None
         
     def exists(self):
         """
         Finds if a collection exists in the cluster
-
-        :param collection: the collection to find
-
+        :return: whether a collection exists in the cluster
+        :rtype: bool
         """
         return self.name in self.connection.list()
 
@@ -31,11 +39,11 @@ class SolrCollectionAdmin(CollectionBase):
         """
         Create a collection
 
-        :param num_shards: an integer indicating the number of shards for this collection
-
         :param replication_factor: an integer indicating the number of replcas for this collection
+        :type replication_factor: int
 
         :param force: a boolean value indicating whether to force the operation
+        :type force: bool
 
         :param kwargs: additional parameters to be passed to this operation
 
@@ -50,20 +58,20 @@ class SolrCollectionAdmin(CollectionBase):
 
         Additional parameters are further documented at https://cwiki.apache.org/confluence/display/solr/Collections+API#CollectionsAPI-CreateaCollection
         """
-        params = {'name':self.name,
-                  'replicationFactor':replication_factor,
-                  'action':'CREATE'}
-        router_name = kwargs.get("router_name",'compositeId')
+        params = {'name': self.name,
+                  'replicationFactor': replication_factor,
+                  'action': 'CREATE'}
+        router_name = kwargs.get("router_name", 'compositeId')
         params['router.name'] = router_name
 
-        num_shards = kwargs.get("num_shards","1")
+        num_shards = kwargs.get("num_shards", "1")
         params['numShards'] = num_shards
 
         shards = kwargs.get("shards")
         if shards:
             params['shards'] = shards
 
-        max_shards_per_node = kwargs.get('max_shards_per_node',1)
+        max_shards_per_node = kwargs.get('max_shards_per_node', 1)
         params['maxShardsPerNode'] = max_shards_per_node
 
         create_node_set = kwargs.get('create_node_set')
@@ -79,151 +87,202 @@ class SolrCollectionAdmin(CollectionBase):
             params['router.field'] = router_field
 
         # this collection doesn't exist yet, actually create it
-        if not self.exists() or force == True:
-            res = self.client.get('admin/collections',params).result
-            if hasattr(res,'success'):
+        if not self.exists() or force:
+            res = self.client.get('admin/collections', params).result
+            if hasattr(res, 'success'):
                 # Create the index and wait until it's available
                 while True:
                     if not self._is_index_created():
                         print "index not created yet, waiting..."
                         time.sleep(1)
-                    else: break
-
+                    else: 
+                        break
                     return SolrCollectionAdmin(self.connection,self.name)
             else:
                 raise SolrException(str(res))
 
         # this collection is already present, just return it
-        return SolrCollectionAdmin(self.connection,self.name)
+        return SolrCollectionAdmin(self.connection, self.name)
 
     def _is_index_created(self):
+        """
+        Whether the index was created
+        :rtype: bool
+        """
         server = list(self.connection.servers)[0]
-        req = requests.get('%s/solr/%s' % (server,self.name))
-        if req.status_code != requests.codes.ok:
-            return False
-        return True
+        req = requests.get('%s/solr/%s' % (server, self.name))
+        return req.status_code == requests.codes.ok
 
     def is_alias(self):
         """
         Determines if this collection is an alias for a 'real' collection
+        :rtype: bool
         """
-        params = {'detail':'true','path':'/aliases.json'}
-        response = self.client.get('/solr/zookeeper',params).result
-        if hasattr(response['znode'],'data'):
-            data = json.loads(response['znode']['data'])
-        else:
-            data = {}
-        if not data:
-            return False
-        collections = data['collection']
-        for alias in collections.iterkeys():
-            if self.name == alias:
-                return True
+        response = self.client.get('/solr/admin/collections', {'action': 'CLUSTERSTATUS', 'wt': 'json'}).result.dict
+        if 'aliases' in response['cluster']:
+            return self.name in response['cluster']['aliases']
         return False
 
     def drop(self):
         """
         Delete a collection
+        
+        :return: a response associated with the delete request
+        :rtype: SolrResponse
         """
-        return self.client.get('admin/collections',{'action':'DELETE','name':self.name}).result
+        return self.client.get('admin/collections', {'action': 'DELETE', 'name': self.name}).result
 
     def reload(self):
         """
         Reload a collection
+        
+        :return: a response associated with the reload request
+        :rtype: SolrResponse
         """
-        return self.client.get('admin/collections',{'action':'RELOAD','name':self.name}).result
+        return self.client.get('admin/collections', {'action': 'RELOAD', 'name': self.name}).result
 
     def split_shard(self, shard, ranges=None, split_key=None):
         """
         Split a shard into two new shards
 
         :param shard: The name of the shard to be split.
+        :type shard: str
         :param ranges: A comma-separated list of hash ranges in hexadecimal e.g. ranges=0-1f4,1f5-3e8,3e9-5dc
+        :type ranges: str
         :param split_key: The key to use for splitting the index
-
+        :type split_key: str
+        :return: a response associated with the splitshard request
+        :rtype: SolrResponse
         """
-        params = {'action':'SPLITSHARD','collection':self.name,'shard':shard}
+        params = {'action': 'SPLITSHARD', 'collection': self.name, 'shard': shard}
         if ranges:
             params['ranges'] = ranges
         if split_key:
             params['split.key'] = split_key
-        return self.client.get('admin/collections',params).result
+        return self.client.get('admin/collections', params).result
 
     def create_shard(self, shard, create_node_set=None):
         """
         Create a new shard
 
         :param shard: The name of the shard to be created.
-
+        :type shard: str
         :param create_node_set: Allows defining the nodes to spread the new collection across.
+        :type create_node_set: str
+        :return: a response associated with the createshard request
+        :rtype: SolrResponse
         """
-        params = {'action':'CREATESHARD','collection':self.name,
-                  'shard':shard }
+        params = {'action': 'CREATESHARD', 'collection': self.name, 'shard': shard}
         if create_node_set:
             params['create_node_set'] = create_node_set
-        return self.client.get('admin/collections',params).result
+        return self.client.get('admin/collections', params).result
 
     def create_alias(self, alias):
         """
         Create or modify an alias for a collection
 
         :param alias: the name of the alias
+        :type alias: str
+        :return: a response associated with the createalias request
+        :rtype: SolrResponse
         """
-        params = {'action':'CREATEALIAS',
-                  'name':alias,'collections':self.name}
-        return self.client.get('admin/collections',params).result
+        params = {'action': 'CREATEALIAS', 'name': alias, 'collections': self.name}
+        return self.client.get('admin/collections', params).result
 
-    def delete_alias(self,alias):
+    def delete_alias(self, alias):
         """
         Delete an alias for a collection
 
         :param alias: the name of the alias
+        :type alias: str
+        :return: a response associated with the deletealias request
+        :rtype: SolrResponse
         """
-        params = {'action':'DELETEALIAS','name':alias,}
-        return self.client.get('admin/collections',params).result
+        params = {'action': 'DELETEALIAS', 'name': alias}
+        return self.client.get('admin/collections', params).result
 
     def delete_replica(self, replica, shard):
         """
         Delete a replica
 
         :param replica:  The name of the replica to remove.
-
+        :type replica: str
         :param shard: The name of the shard that includes the replica to be removed.
+        :type shard: str
+        :return: a response associated with the deletereplica request
+        :rtype: SolrResponse
         """
-        params = {'action':'DELETEREPLICA',
-                  'replica':replica,
-                  'collection':self.name,
-                  'shard':shard}
-        return self.client.get('admin/collections',params).result
-
+        params = {'action': 'DELETEREPLICA',
+                  'replica': replica,
+                  'collection': self.name,
+                  'shard': shard}
+        return self.client.get('admin/collections', params).result
 
     @property
     def state(self):
-        """Get the state of this collection"""
+        """
+        Get the state of this collection
+        
+        :return: the state of this collection
+        :rtype: dict
+        """
         if self.is_alias():
-            return {"warn":"no state info avilable for aliases"}
+            return {"warn": "no state info avilable for aliases"}
 
-        params = {'detail':'true','path':'/clusterstate.json'}
-        response = self.client.get('/solr/zookeeper',params).result
+        params = {'detail': 'true', 'path': '/clusterstate.json'}
+        response = self.client.get('/solr/zookeeper', params).result
         data = json.loads(response['znode']['data'])
         return data[self.name]
 
     @property
     def shards(self):
+        """
+        See state method
+        :rtype: dict
+        """
         return self.state
 
     @property
     def index_info(self):
         """
         Get a high-level overview of this collection's index
+        :return: information about an index
+        :rtype: dict
         """
-        response = self.client.get('%s/admin/luke' % self.name,{}).result
+        response = self.client.get('%s/admin/luke' % self.name, {}).result
         # XXX ugly
         data = response['index'].dict
-        data.pop('directory',None)
-        data.pop('userData',None)
+        data.pop('directory', None)
+        data.pop('userData', None)
         return data
 
     @property
+    def index_stats(self):
+        """
+        Retrieves the SolrIndexStats class
+        :return: SolrIndexStats class
+        :rtype: SolrIndexStats
+        """
+        if self._index_stats is None:
+            self._index_stats = SolrIndexStats(self.connection, self.name)
+        return self._index_stats
+    
+    @property
+    def schema(self):
+        """
+        Retrieves the SolrSchema class
+        :return: SolrSchema class
+        :rtype: SolrSchema
+        """
+        if self._schema is None:
+            self._schema = SolrSchema(self.connection, self.name)
+        return self._schema
+
+    @property
     def stats(self):
+        """
+        Alias for retrieving the SolrIndexStats class
+        :return: SolrIndexStats class
+        :rtype: SolrIndexStats
+        """
         return self.index_stats

--- a/solrcloudpy/collection/indexer.py
+++ b/solrcloudpy/collection/indexer.py
@@ -6,24 +6,30 @@ import logging
 
 log = logging.getLogger('solrcloud')
 
-class SolrBatchAdder(object):
-    def __init__(self, solr, batch_size=100, auto_commit=True):
-        """Provides an abstraction for batching commits to the Solr
-        index when processing documents with pysolr.  `SolrBatchAdder` maintains an internal
-        "batch" list, and  when it reaches `batch_size`, it will commit the batch to
-        Solr.  This allows for overall better performance when committing large numbers of
-        documents.
 
+class SolrBatchAdder(object):
+    """
+    Provides an abstraction for batching commits to the Solr
+    index when processing documents with pysolr.  `SolrBatchAdder` maintains an internal
+    "batch" list, and  when it reaches `batch_size`, it will commit the batch to
+    Solr.  This allows for overall better performance when committing large numbers of
+    documents.
+    """
+    def __init__(self, solr, batch_size=100, auto_commit=True):
+        """
         `batch_size` is 100 by default; different values may yield
         different performance characteristics, and this of course depends upon your average
         document size and Solr schema.  But 100 seems to improve performance
         significantly over single commits.
 
         :param solr: a `SolrIndex` object representing the solr index to use
+        :type solr: SolrIndex
 
         :param batch_size: the number of documents to commit at a time. The default is 100
+        :type batch_size: int
 
         :param auto_commit: whether to commit after adding each batch of documents
+        :type auto_commit: bool
         """
         self.solr = solr
         self.batch = list()
@@ -37,6 +43,7 @@ class SolrBatchAdder(object):
         if we've reached batch_size.
 
         :param doc: the document
+        :type doc: dict
         """
         self._append_commit(doc)
 
@@ -47,6 +54,7 @@ class SolrBatchAdder(object):
         if batch_size is reached.
 
         :param docs_iter: the list of documents to go through
+        :type docs_iter: iterable
         """
         assert hasattr(docs_iter, "__iter__"), "docs_iter must be iterable"
         for doc in docs_iter:
@@ -81,19 +89,30 @@ class SolrBatchAdder(object):
         self.batch_len = 0
 
     def commit(self):
-        """Commit the current batch of documents """
+        """Commit the current batch of documents"""
         try:
             self.solr.commit()
-        except :
-            log.warning("SolrBatchAdder timed out when committing, but   it's safe to ignore")
+        except Exception as e:
+            log.warning("SolrBatchAdder timed out when committing, but it's safe to ignore")
 
     def _append_commit(self, doc):
+        """
+        Adds a doc with an optional commit
+        :param doc: the document we want to send to solr
+        :type doc: dict
+        """
         if self.batch_len == self.batch_size:
             # flush first, because we are at our batch size
             self.flush()
         self._add_to_batch(doc)
 
     def _add_to_batch(self, doc):
+        """
+        Adds a document and tracks it within a batch context
+        
+        :param doc: the document to send to solr
+        :type doc: dict
+        """
         self.batch.append(doc)
         self.batch_len += 1
 
@@ -101,16 +120,20 @@ class SolrBatchAdder(object):
         fmt = "SolrBatchAdder(batch_size={batch_size},  batch_len={batch_len}, solr={solr}"
         return fmt.format(**vars(self))
 
+
 @contextmanager
 def solr_batch_adder(solr, batch_size=2000, auto_commit=False):
     """
     A context manager for adding documents in solr
 
     :param solr: a `SolrIndex` object representing the solr index to use
+    :type solr: SolrIndex
 
     :param batch_size: the number of documents to commit at a time. The default is 100
+    :type batch_size: int
 
     :param auto_commit: whether to commit after adding each batch of documents
+    :type auto_commit: bool
     """
     batcher = SolrBatchAdder(solr, batch_size, auto_commit)
     try:

--- a/solrcloudpy/collection/schema.py
+++ b/solrcloudpy/collection/schema.py
@@ -3,118 +3,163 @@ Get and modify schema
 """
 from solrcloudpy.utils import _Request
 
+
 class SolrSchema(object):
     """
-    Get and modify schema
+    Get and modify schema.
+    Uses the Schema API described in https://cwiki.apache.org/confluence/display/solr/Schema+API
     """
-    def __init__(self,connection,collection_name):
+    def __init__(self, connection, collection_name):
+        """
+        :param connection: the connection to solr
+        :type connection: SolrConnection
+        :param collection_name: the name of the collection related to the schema
+        :type collection_name: str
+        """
         self.connection = connection
         self.collection_name = collection_name
         self.client = _Request(connection)
 
     @property
     def schema(self):
-        path = '%s/schema'% (self.collection_name)
-        return self.client.get(path,{}).result.dict
+        """
+        Retrieves the schema as a dict
+        :return: the schema dict
+        :rtype: dict
+        """
+        return self.client.get('%s/schema' % self.collection_name).result.dict
 
     @property
     def name(self):
-        path = '%s/schema/name'% (self.collection_name)
-        return self.client.get(path,{}).result.dict
+        """
+        Retrieves the schema name as a dict
+        :return: the schema name as a dict
+        :rtype: dict
+        """
+        return self.client.get('%s/schema/name' % self.collection_name).result.dict
 
     @property
     def version(self):
-        path = '%s/schema/version'% (self.collection_name)
-        return self.client.get(path,{}).result.dict
+        """
+        Retrieves the schema version as a dict
+        :return: the schema version as a dict
+        :rtype: dict
+        """
+        return self.client.get('%s/schema/version' % self.collection_name).result.dict
 
     @property
     def unique_key(self):
-        path = '%s/schema/uniquekey'% (self.collection_name)
-        return self.client.get(path,{}).result.dict
+        """
+        Retrieves the schema's defined unique key as a dict
+        :return: the schema unique key as a dict
+        :rtype: dict
+        """
+        return self.client.get('%s/schema/uniquekey' % self.collection_name).result.dict
 
     @property
     def similarity(self):
-        path = '%s/schema/similarity'% (self.collection_name)
-        return self.client.get(path,{}).result.dict
+        """
+        Retrieves the schema's global similarity definition as a dict
+        :return: the schema global similarity definition as a dict
+        :rtype: dict
+        """
+        return self.client.get('%s/schema/similarity' % self.collection_name).result.dict
 
     @property
     def default_operator(self):
-        path = '%s/schema/solrqueryparser/defaultoperator'% (self.collection_name)
-        return self.client.get(path,{}).result.dict
+        """
+        Retrieves the schema's defualt operator as a dict
+        :return: the schema default operator as a dict
+        :rtype: dict
+        """
+        return self.client.get('%s/schema/solrqueryparser/defaultoperator' % self.collection_name).result.dict
 
-    ## fields
-    def get_field(self,field):
+    def get_field(self, field):
         """
         Get information about a field in the schema
+        TODO: looks like this API will change in newer versions of solr
 
         :param field: the name of the field
+        :type field: str
+        :return: a dict related to the field definition
+        :rtype: dict
         """
-        path = '%s/schema/field/%s'% (self.collection_name,field)
-        return self.client.get(path,{}).result.dict
+        return self.client.get('%s/schema/field/%s' % (self.collection_name, field)).result.dict
 
     def get_fields(self):
         """
         Get information about all field in the schema
+        
+        :return: a dict of fields to their schema definitions
+        :rtype: dict
         """
-        path = '%s/schema/fields'%self.collection_name
-        return self.client.get(path,{}).result.dict
+        return self.client.get('%s/schema/fields' % self.collection_name).result.dict
 
-    def add_fields(self,json_schema):
+    def add_fields(self, json_schema):
         """
         Add fields to the schema
 
-        :param json_schema: specs for the fields to add
+        :param json_schema: specs for the fields to add -- should be a json string
+        :type json_schema: str
+        :return: a dict representing the result of the update request
+        :rtype: dict
         """
-        path = '%s/schema/fields'%self.collection_name
-        return self.client.update(path,{},json_schema).result.dict
+        return self.client.update('%s/schema/fields' % self.collection_name, body=json_schema).result.dict
 
-    ## dynamic fields
     def get_dynamic_fields(self):
         """
         Get information about a dynamic field in the schema
+        :return: a dict of dynamic fields to their schema definitions
+        :rtype: dict
         """
-        path = '%s/schema/dynamicfields'%self.collection_name
-        return self.client.get(path,{}).result.dict
+        return self.client.get('%s/schema/dynamicfields' % self.collection_name).result.dict
 
-    def get_dynamic_field(self,field):
+    def get_dynamic_field(self, field):
         """
         Get information about a dynamic field in the schema
+        TODO: this will change in later version of solr
 
         :param field: the name of the field
+        :type field: str
+        :return: a dict of dynamic fields to their schema definitions
+        :rtype: dict
         """
-        path = '%s/schema/dynamicfield/%s'%(self.collection_name,field)
-        return self.client.get(path,{}).result.dict
+        return self.client.get('%s/schema/dynamicfield/%s' % (self.collection_name, field)).result.dict
 
-    ## field types
     def get_fieldtypes(self):
         """
         Get information about field types in the schema
+        :return: a dict relating information about field types
+        :rtype: dict
         """
-        path = '%s/schema/fieldtypes'%(self.collection_name)
-        return self.client.get(path,{}).result.dict
+        return self.client.get('%s/schema/fieldtypes' % (self.collection_name)).result.dict
 
-    def get_fieldtype(self,ftype):
+    def get_fieldtype(self, ftype):
         """
         Get information about a field type in the schema
 
         :param ftype: the name of the field type
+        :type ftype: str
+        :return: a dict relating information about a given field type
+        :rtype: dict
         """
-        path = '%s/schema/fieldtypes/%s'%(self.collection_name,ftype)
-        return self.client.get(path,{}).result.dict
+        return self.client.get('%s/schema/fieldtypes/%s' % (self.collection_name, ftype)).result.dict
 
-    ## copy fields
     def get_copyfields(self):
         """
         Get information about all copy field in the schema
+        :return: a dict describing the copyfields defined in the schema
+        :rtype: dict
         """
-        path = '%s/schema/copyfields'%self.collection_name
-        return self.client.get(path,{}).result.dict
+        return self.client.get('%s/schema/copyfields' % self.collection_name).result.dict
 
-    def get_copyfield(self,field):
+    def get_copyfield(self, field):
         """
         Get information about a copy field in the schema
 
         :param ftype: the name of the field type
+        :type ftype: str
+        :return: a dict relating information about a given copyfield
+        :rtype: dict
         """
-        path = '%s/schema/copyfield/%s'%(self.collection_name,field)
-        return self.client.get(path,{}).result.dict
+        return self.client.get('%s/schema/copyfield/%s' % (self.collection_name, field)).result.dict

--- a/solrcloudpy/collection/stats.py
+++ b/solrcloudpy/collection/stats.py
@@ -1,13 +1,20 @@
 """
-Get different statistics about the undelying index in a collection
+Get different statistics about the underlying index in a collection
 """
 from solrcloudpy.utils import _Request, SolrResult
 
+
 class SolrIndexStats(object):
     """
-    Get different statistics about the undelying index in a collection
+    Get different statistics about the underlying index in a collection
     """
-    def __init__(self,connection,name):
+    def __init__(self, connection, name):
+        """
+        :param connection: the connection to solr
+        :type connection: SolrConnection
+        :param name: the name of the index
+        :type name: str
+        """
         self.connection = connection
         self.name = name
         self.client = _Request(connection)
@@ -18,14 +25,16 @@ class SolrIndexStats(object):
         Get cache statistics about the index.
         We retrieve cache stats for the document, filter, fiedvalue, fieldcache caches
 
+        :return: The result
+        :rtype: SolrResult
         """
-        params = {'stats':'true','cat':'CACHE'}
-        result = self.client.get('/solr/%s/admin/mbeans'% self.name,params).result.dict
+        params = {'stats': 'true', 'cat': 'CACHE'}
+        result = self.client.get('/solr/%s/admin/mbeans' % self.name, params).result.dict
         caches = result['solr-mbeans']['CACHE']
         res = {}
-        for cache,info in caches.iteritems():
+        for cache, info in caches.iteritems():
             if cache == 'fieldCache':
-                res[cache] = {'entries_count':info['stats'].get('entries_count',0)}
+                res[cache] = {'entries_count': info['stats'].get('entries_count', 0)}
                 continue
 
             res[cache] = info['stats']
@@ -36,12 +45,15 @@ class SolrIndexStats(object):
     def queryhandler_stats(self):
         """
         Get query handler statistics for all of the handlers used in this Solr node
+        
+        :return: The result
+        :rtype: SolrResult
         """
-        params = {'stats':'true','cat':'QUERYHANDLER'}
-        result = self.client.get('/solr/%s/admin/mbeans'% self.name,params).result.dict
+        params = {'stats': 'true', 'cat': 'QUERYHANDLER'}
+        result = self.client.get('/solr/%s/admin/mbeans' % self.name, params).result.dict
         caches = result['solr-mbeans']['QUERYHANDLER']
         res = {}
-        for cache,info in caches.iteritems():
+        for cache, info in caches.iteritems():
             res[cache] = info['stats']
 
         return SolrResult(res)

--- a/solrcloudpy/connection.py
+++ b/solrcloudpy/connection.py
@@ -26,12 +26,18 @@ class SolrConnection(object):
     Connection to a solr server or several ones
 
     :param server: The server. Can be a single one or a list of servers. Example  ``localhost:8983`` or ``[localhost,solr1.domain.com:8983]``.
+    :type server: str
     :param detect_live_nodes: whether to detect live nodes automativally or not. This assumes that one is able to access the IPs listed by Zookeeper. The default value is ``False``.
+    :type detect_live_nodes: bool
 
     :param user: HTTP basic auth user name
+    :type user: str
     :param password: HTTP basic auth password
+    :type password: str
     :param timeout: timeout for HTTP requests
+    :type timeout: int
     :param webappdir: the solr webapp directory; defaults to 'solr'
+    :type webappdir: str
     """
 
     def __init__(self, server="localhost:8983",
@@ -46,7 +52,7 @@ class SolrConnection(object):
         self.webappdir = webappdir
         self.url_template = 'http://{{server}}/{webappdir}/'.format(webappdir=self.webappdir)
 
-        if type(server) == type(''):
+        if type(server) == str:
             self.url = self.url_template.format(server=server)
             servers = [self.url, self.url]
             if detect_live_nodes:
@@ -54,7 +60,7 @@ class SolrConnection(object):
                 self.servers = self.detect_nodes(url)
             else:
                 self.servers = servers
-        if type(server) == type([]):
+        if type(server) == list:
             servers = [self.url_template.format(server=a) for a in server]
             if detect_live_nodes:
                 url = servers[0]
@@ -64,8 +70,18 @@ class SolrConnection(object):
 
         self.client = _Request(self)
 
-    def detect_nodes(self, url):
-        url = url + 'zookeeper?path=/live_nodes'
+    def detect_nodes(self, base_url):
+        """
+        Queries Solr's zookeeper integration for live nodes
+        
+        todo: this is pretty dense, maybe brittle?
+        
+        :param base_url: the base url for solr
+        :type base_url: str
+        :return: a list of sorl URLs corresponding to live nodes in solrcloud
+        :rtype: list
+        """
+        url = base_url+'zookeeper?path=/live_nodes'
         live_nodes = urllib.urlopen(url).read()
         data = json.loads(live_nodes)
         children = [d['data']['title'] for d in data['tree'][0]['children']]
@@ -75,17 +91,41 @@ class SolrConnection(object):
     def list(self):
         """
         Lists out the current collections in the cluster
+        This should probably be a recursive function but I'm not in the mood today
+        
+        :return: a list of collection names
+        :rtype: list
         """
         params = {'detail': 'false', 'path': '/collections'}
         response = self.client.get(
             ('/{webappdir}/zookeeper'.format(webappdir=self.webappdir)), params).result
+        
         if 'children' not in response['tree'][0]:
             return []
-        data = response['tree'][0]['children']
+
+        if response['tree'][0]['data']['title'] == '/collections':
+            # solr 5.3 and older
+            data = response['tree'][0]['children']
+        else:
+            # solr 5.4+
+            data = None
+            for branch in response['tree']:
+                if data is not None:
+                    break
+                for child in branch['children']:
+                    if child['data']['title'] == '/collections':
+                        data = child['children']
+                        break
+
         colls = [node['data']['title'] for node in data]
         return colls
 
     def _list_cores(self):
+        """
+        Retrieves a list of cores from solr admin
+        :return: a list of cores
+        :rtype: list
+        """
         params = {'wt': 'json', }
         response = self.client.get(
             ('/{webappdir}/admin/cores'.format(webappdir=self.webappdir)), params).result
@@ -97,6 +137,9 @@ class SolrConnection(object):
         """
         Determine the state of all nodes and collections in the cluster. Problematic nodes or
         collections are returned, along with their state, otherwise an `OK` message is returned
+        
+        :return: a dict representing the status of the cluster
+        :rtype: dict
         """
         params = {'detail': 'true', 'path': '/clusterstate.json'}
         response = self.client.get(
@@ -127,16 +170,31 @@ class SolrConnection(object):
     def cluster_leader(self):
         """
         Gets the cluster leader
+        
+        :rtype: dict
+        :return: a dict with the json loaded from the zookeeper response related to the cluster leader request
         """
-        params = {'detail': 'true', 'path': '/overseer_elect/leader'}
-        response = self.client.get(
-            ('/{webappdir}/zookeeper'.format(webappdir=self.webappdir)), params).result
-        return json.loads(response['znode']['data'])
+        try:
+            # 5.3 or less
+            params = {'detail': 'true', 'path': '/overseer_elect/leader'}
+            response = self.client.get(
+                ('/{webappdir}/zookeeper'.format(webappdir=self.webappdir)), params).result
+            return json.loads(response['znode']['data'])
+        except:
+            # 5.4+
+            # todo something smarter than exception handling
+            params = {'detail': 'true', 'path': '/overseer_elect/leader'}
+            response = self.client.get(
+                ('/{webappdir}/admin/zookeeper'.format(webappdir=self.webappdir)), params).result
+            return json.loads(response['znode']['data'])
 
     @property
     def live_nodes(self):
         """
         Lists all nodes that are currently online
+        
+        :return: a list of urls related to live nodes
+        :rtype: list
         """
         params = {'detail': 'true', 'path': '/live_nodes'}
         response = self.client.get(
@@ -150,20 +208,47 @@ class SolrConnection(object):
         Create a collection.
 
         :param collname: The collection name
-        :param \*args: additiona arguments
+        :type collname: str
+        :param \*args: additional arguments
         :param \*\*kwargs: additional named parameters
+        
+        :return: the created collection
+        :rtype: SolrCollection
         """
         coll = collection.SolrCollection(self, collname)
         return coll.create(*args, **kwargs)
 
     def __getattr__(self, name):
+        """
+        Convenience method for retrieving a solr collection
+        :param name: the name of the collection
+        :type name: str
+        :return: SolrCollection
+        """
         return collection.SolrCollection(self, name)
 
     def __getitem__(self, name):
+        """
+        Convenience method for retrieving a solr collection
+        :param name: the name of the collection
+        :type name: str
+        :return: SolrCollection
+        """
         return collection.SolrCollection(self, name)
 
     def __dir__(self):
+        """
+        Convenience method for viewing servers available in this connection
+        
+        :return: a list of servers
+        :rtype: list
+        """
         return self.list()
 
     def __repr__(self):
+        """
+        Representation in Python outputs
+        :return: string representation
+        :rtype: str
+        """
         return "SolrConnection %s" % str(self.servers)

--- a/solrcloudpy/parameters.py
+++ b/solrcloudpy/parameters.py
@@ -4,6 +4,10 @@ from collections import defaultdict
 class BaseParams(object):
 
     def __init__(self, query=None, **kwargs):
+        """
+        :param query: the query to send to solr
+        :type query: str
+        """
         self._q = defaultdict(set)
         if query:
             self._q['q'].add(query)
@@ -15,6 +19,11 @@ class BaseParams(object):
                 self._q[k].update([v])
 
     def add_params(self, **kwargs):
+        """
+        Takes keyword arguments and adds them as key-value pairs to params to be sent to solr
+        :return: self
+        :rtype: BaseParams
+        """
         for k, v in kwargs.items():
             if hasattr(v, "__iter__"):
                 self._q[k].update(v)
@@ -23,23 +32,48 @@ class BaseParams(object):
         return self
 
     def remove_param(self, key):
+        """
+        Removes a parameter from the request being prepared
+        """
         self._q.pop(key, None)
 
     def __repr__(self):
+        """
+        :return: str
+        :rtype: str
+        """
         c = self._q.copy()
         return repr(dict(c))
 
     def __iter__(self):
+        """
+        :return: an iterable
+        :rtype: iterable
+        """
         c = self._q.copy()
         return c.iteritems()
 
     def __getitem__(self, item):
+        """
+        Convenience method to allow retrieval from param keys
+        :param item: the key
+        :type item: str
+        :return: the value stored under that key
+        """
         return self._q[item]
 
     def iterkeys(self):
+        """
+        :return: an iterable
+        :rtype: iterable
+        """
         return self._q.iterkeys()
 
     def __len__(self):
+        """
+        :return: size of the params
+        :rtype: int
+        """
         return len(self._q)
 
 
@@ -51,50 +85,129 @@ class CommonParams(BaseParams):
     """
 
     def q(self, query):
+        """
+        Adds query parameter
+        :param query: the query to be sent to solr
+        :type query: str
+        :return: self for fluent interface
+        :rtype: CommonParams
+        """
         self._q['q'].add(query)
         return self
 
     def sort(self, criteria):
+        """
+        Adds sort parameter
+        :param criteria: the sort directive to be sent to solr
+        :type criteria: str
+        :return: self for fluent interface
+        :rtype: CommonParams
+        """
         self._q['sort'].add(criteria)
         return self
 
     def start(self, start):
+        """
+        Adds start parameter to solr request
+        :param start: starting result offset to be requested from solr
+        :type start: int
+        :return: self for fluent interface
+        :rtype: CommonParams
+        """
         self._q['start'].add(start)
         return self
 
     def rows(self, r):
+        """
+        Adds start parameter to solr request
+        :param start: starting result offset to be requested from solr
+        :type start: int
+        :return: self for fluent interface
+        :rtype: CommonParams
+        """
         self._q['rows'].add(r)
         return self
 
     def fq(self, query):
+        """
+        Adds filter query parameter to solr request
+        :param fq: filter query
+        :type fq: str
+        :return: self for fluent interface
+        :rtype: CommonParams
+        """
         self._q['fq'].add(query)
         return self
 
     def fl(self, fields):
+        """
+        Adds field parameter to solr request
+        :param fields: comma-separated field names
+        :type fields: str
+        :return: self for fluent interface
+        :rtype: CommonParams
+        """
         self._q['fl'].add(fields)
         return self
 
     def deftype(self, t):
+        """
+        Allows specification of parser during request handling
+        :param t: a string name of parser type, e.g. lucene, edismax
+        :type t: str
+        :return: self for fluent interface
+        :rtype: CommonParams
+        """
         self._q['defType'].add(t)
         return self
 
     def explain_other(self, val):
+        """
+        Asks Solr to explain how documents matching a particular query were graded against the query used
+        :param val: a query string
+        :type val: str
+        :return: self for fluent interface
+        :rtype: CommonParams
+        """
         self._q['explainOther'].add(val)
         return self
 
     def time_allowed(self, t):
+        """
+        Add timeout to search
+        :param t: a timeout value
+        :type t: int
+        :return: self for fluent interface
+        :rtype: CommonParams
+        """
         self._q['timeAllowed'].add(t)
         return self
 
     def cache(self, val):
+        """
+        Allows definition of caching of filters, causes filtering to be done at the same time as search
+        :param val: true or false string
+        :type val: str
+        :return: self for fluent interface
+        :rtype: CommonParams
+        """
         self._q['cache'].add(val)
         return self
 
     def log_param_list(self, val):
+        """
+        This isn't in Solr's documentation...
+        """
         self._q['logParamList'].add(val)
         return self
 
     def debug(self):
+        """
+        Enables debugging for a particular query
+        
+        :return: self for fluent interface
+        :rtype: CommonParams
+        """
         self._q['debug'].add("true")
         return self
 
@@ -106,42 +219,112 @@ class MLTParams(BaseParams):
     """
 
     def fl(self, field):
+        """
+        Adds field parameter to solr mlt request
+        :param field: comma-separated field names
+        :type field: str
+        :return: self for fluent interface
+        :rtype: MTLParams
+        """
         self._q['mlt.fl'].add(field)
         return self
 
     def mintf(self, tf):
+        """
+        Adds minimum term frequency parameter to solr mlt request
+        :param tf: the minimum term frequency
+        :type tf: float
+        :return: self for fluent interface
+        :rtype: MTLParams
+        """
         self._q['mlt.mintf'].add(tf)
         return self
 
     def mindf(self, df):
+        """
+        Adds minimum document frequency parameter to solr mlt request
+        :param df: the minimum document frequency
+        :type df: float
+        :return: self for fluent interface
+        :rtype: MTLParams
+        """
         self._q['mlt.mindf'].add(df)
         return self
 
     def minwl(self, wl):
+        """
+        Adds minimum word length parameter to solr mlt request
+        :param wl: the minimum word length
+        :type wl: int
+        :return: self for fluent interface
+        :rtype: MTLParams
+        """
         self._q['mlt.minwl'].add(wl)
         return self
 
     def maxwl(self, wl):
+        """
+        Adds maximum word length parameter to solr mlt request
+        :param wl: the maximum word length
+        :type wl: int
+        :return: self for fluent interface
+        :rtype: MTLParams
+        """
         self._q['mlt.maxwl'].add(wl)
         return self
 
     def maxqt(self, qt):
+        """
+        Adds maximum query terms parameter to solr mlt request
+        :param qt: the maximum query terms
+        :type qt: int
+        :return: self for fluent interface
+        :rtype: MTLParams
+        """
         self._q['mlt.maxqt'].add(qt)
         return self
 
     def maxntp(self, ntp):
+        """
+        Adds maximum number of tokens to parse parameter to solr mlt request
+        :param ntp: the maximum number of tokens to parse
+        :type ntp: int
+        :return: self for fluent interface
+        :rtype: MTLParams
+        """
         self._q['mlt.maxntp'].add(ntp)
         return self
 
     def boost(self, val):
+        """
+        Sets if the query will be boosted by the interesting term service
+        :param val: a string boolean (lowercase)
+        :type val: str
+        :return: self for fluent interface
+        :rtype: MTLParams
+        """
         self._q['mlt.boost'].add(val)
         return self
 
     def qf(self, fields):
+        """
+        Specifies the query fields
+        :param fields: a string of comma-separated fields
+        :type fields: str
+        :return: self for fluent interface
+        :rtype: MTLParams
+        """
         self._q['mlt.qf'].add(fields)
         return self
 
     def count(self, c):
+        """
+        Number of similar documents to return for each result
+        :param c: the number of similar documents desired
+        :type c: int
+        :return: self for fluent interface
+        :rtype: MTLParams
+        """
         self._q['mlt.count'].add(c)
         return self
 
@@ -153,14 +336,37 @@ class FacetParams(BaseParams):
     """
 
     def query(self, query):
+        """
+        The facet query
+        :param query: the query to facet against
+        :type query: str
+        :return: self for fluent interface
+        :rtype: FacetParams
+        """
         self._q['facet.query'].add(query)
         return self
 
     def field(self, field):
+        """
+        The facet field
+        :param field: the field we want facets for
+        :type field: str
+        :return: self for fluent interface
+        :rtype: FacetParams
+        """
         self._q['facet.field'].add(field)
         return self
 
     def prefix(self, criteria, field=None):
+        """
+        The facet prefix
+        :param criteria: the prefix to filter your facets
+        :type criteria: str
+        :param field: specify a field to prefix against
+        :type field: str
+        :return: self for fluent interface
+        :rtype: FacetParams
+        """
         if field:
             self._q['f.%s.facet.prefix' % field].add(criteria)
         else:
@@ -168,6 +374,15 @@ class FacetParams(BaseParams):
         return self
 
     def sort(self, criteria, field=None):
+        """
+        The facet prefix
+        :param criteria: how to sort facets -- one of "count" or "index"
+        :type criteria: str
+        :param field: specify a field to sort against
+        :type field: str
+        :return: self for fluent interface
+        :rtype: FacetParams
+        """
         if criteria not in ["count", "index"]:
             criteria = "count"
 
@@ -179,6 +394,15 @@ class FacetParams(BaseParams):
         return self
 
     def limit(self, limit, field=None):
+        """
+        Limit the number of facet results
+        :param limit: the number of results
+        :type limit: int
+        :param field: specify a field to limit against
+        :type field: str
+        :return: self for fluent interface
+        :rtype: FacetParams
+        """
         if field:
             self._q['f.%s.facet.limit' % field].add(limit)
         else:
@@ -186,6 +410,15 @@ class FacetParams(BaseParams):
         return self
 
     def offset(self, offset, field=None):
+        """
+        Facet result offset
+        :param offset: the result offset
+        :type offset: int
+        :param field: specify a field to offset against
+        :type field: str
+        :return: self for fluent interface
+        :rtype: FacetParams
+        """
         if field:
             self._q['f.%s.facet.offset' % field].add(offset)
         else:
@@ -193,6 +426,15 @@ class FacetParams(BaseParams):
         return self
 
     def mincount(self, count, field=None):
+        """
+        Specify a minimum number of results required
+        :param count: the facet result minimum
+        :type count: int
+        :param field: specify a field to apply filter against
+        :type field: str
+        :return: self for fluent interface
+        :rtype: FacetParams
+        """
         if field:
             self._q['f.%s.facet.mincount' % field].add(count)
         else:
@@ -200,6 +442,15 @@ class FacetParams(BaseParams):
         return self
 
     def missing(self, val, field=None):
+        """
+        Whether to include values missing from facet query
+        :param val: a boolean string
+        :type val: str
+        :param field: specify a field to apply this to
+        :type field: str
+        :return: self for fluent interface
+        :rtype: FacetParams
+        """
         if field:
             self._q['f.%s.facet.missing' % field].add(val)
         else:
@@ -207,6 +458,15 @@ class FacetParams(BaseParams):
         return self
 
     def method(self, m, field=None):
+        """
+        Which faceting method to use
+        :param m: the facet method, one of ['enum', 'fc', 'fcs']
+        :type m: str
+        :param field: specify a field to apply this to
+        :type field: str
+        :return: self for fluent interface
+        :rtype: FacetParams
+        """
         if field:
             self._q['f.%s.facet.method' % field].add(m)
         else:
@@ -214,6 +474,15 @@ class FacetParams(BaseParams):
         return self
 
     def mindf(self, val, field=None):
+        """
+        Adds minimum document frequency parameter to solr mlt request
+        :param val: the minimum document frequency
+        :type val: float
+        :param field: specify a field to apply this to
+        :type field: str
+        :return: self for fluent interface
+        :rtype: FacetParams
+        """
         if field:
             self._q['f.%s.facet.enum.cache.minDf' % field].add(val)
         else:
@@ -221,10 +490,30 @@ class FacetParams(BaseParams):
         return self
 
     def threads(self, num):
+        """
+        Number of threads to use for this facet request
+        :param num: the number of threads
+        :type num: int
+        :return: self for fluent interface
+        :rtype: FacetParams
+        """
         self._q['facet.threads'].add(num)
         return self
 
     def range(self, field, start, end, gap):
+        """
+        Allows us to specify facet ranges for a given field
+        :param field: the field
+        :type field: str
+        :param start: the starting offset
+        :type start: int
+        :param end: where the facet range ends
+        :type end: int 
+        :param gap: the gap of each faceted range
+        :type gap: int
+        :return: self for fluent interface
+        :rtype: FacetParams
+        """
         self._q['facet.range'].add(field)
         self._q['f.%s.facet.range.start' % field].add(start)
         self._q['f.%s.facet.range.end' % field].add(end)
@@ -232,10 +521,24 @@ class FacetParams(BaseParams):
         return self
 
     def pivot(self, fields):
+        """
+        Allow for decision-tree faceting
+        :param fields: a comma-separated list of fields to pivot against
+        :type fields: str
+        :return: self for fluent interface
+        :rtype: FacetParams
+        """
         self._q['facet.pivot'].add(fields)
         return self
 
     def pivot_mincount(self, count):
+        """
+        Specify the minimum number of results in a given pivot
+        :param count: the minimum number
+        :type count: int
+        :return: self for fluent interface
+        :rtype: FacetParams
+        """
         self._q['facet.pivot.mincount'].add(count)
         return self
 

--- a/solrcloudpy/utils.py
+++ b/solrcloudpy/utils.py
@@ -60,7 +60,7 @@ class _Request(object):
         if method.lower() != 'get':
             headers = {'content-type': 'application/json'}
 
-        # https://github.com/dfdeshom/solrcloudpy/issues/21
+        # https://github.com/solrcloudpy/solrcloudpy/issues/21
         # https://wiki.apache.org/solr/SolJSON
         resparams = {'wt': 'json',
                      'omitHeader': 'true',

--- a/solrcloudpy/utils.py
+++ b/solrcloudpy/utils.py
@@ -9,6 +9,17 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+def as_json_bool(value):
+    """
+    Casts a value as a json-compatible boolean string
+    :param value: the value we want to force to a json-compatible boolean string
+    :type value: bool
+    :return: json-compatible boolean string
+    :rtype: str
+    """
+    return str(bool(value)).lower()
+
+
 class _Request(object):
 
     """
@@ -16,6 +27,10 @@ class _Request(object):
     """
 
     def __init__(self, connection):
+        """
+        :param connection: the solr connection
+        :type connection: SolrConnection
+        """
         self.connection = connection
         self.client = requests.Session()
         self.timeout = connection.timeout
@@ -23,21 +38,30 @@ class _Request(object):
             self.client.auth = HTTPBasicAuth(
                 self.connection.user, self.connection.password)
 
-    def request(self, path, params, method='GET', body=None):
+    def request(self, path, params={}, method='GET', body=None):
         """
         Send a request to a collection
 
         :param path: The relative path of the request
+        :type path: str
         :param params: The parameters of this request. Has to be an objects that implements `iteritems`. Most often this will be an instance :class:`~solrcloudpy.parameter.SearchOptions` or a dictionary
+        :type params: SearchOptions
+        :type params: dict
         :param method: The request method, e.g. `GET`
-        :param body: The request body, if any
+        :type method: str
+        :param body: The request body, if any -- should be a json string
+        :type body: str
 
         :returns response: an instance of :class:`~solrcloudpy.utils.SolrResponse`
+        :rtype: SolrResponse
+        :raise: SolrException
         """
         headers = {}
         if method.lower() != 'get':
             headers = {'content-type': 'application/json'}
 
+        # https://github.com/dfdeshom/solrcloudpy/issues/21
+        # https://wiki.apache.org/solr/SolJSON
         resparams = {'wt': 'json',
                      'omitHeader': 'true',
                      'json.nl': 'map'}
@@ -46,11 +70,18 @@ class _Request(object):
             resparams.update(params.iteritems())
 
         servers = list(self.connection.servers)
+        
+        if not servers:
+            raise SolrException("No servers available")
+        
         random.shuffle(servers)
 
         result = None
         while len(servers) > 0 and result is None:
-            host = servers.pop(0)
+            try:
+                host = servers.pop(0)
+            except IndexError:
+                raise SolrException("No servers available")
             fullpath = urlparse.urljoin(host, path)
             try:
                 r = self.client.request(method, fullpath,
@@ -72,10 +103,34 @@ class _Request(object):
 
         return result
 
-    def update(self, path, params, body):
+    def update(self, path, params={}, body=None):
+        """
+        Posts an update request to Solr
+        
+        :param path: the path to the collection
+        :type path: str
+        :param params: query params
+        :type params: dict
+        :param body: the request body, a json string
+        :type body: str
+        :returns response: an instance of :class:`~solrcloudpy.utils.SolrResponse`
+        :rtype: SolrResponse
+        :raise: SolrException
+        """
         return self.request(path, params, 'POST', body)
 
-    def get(self, path, params):
+    def get(self, path, params={}):
+        """
+        Sends a get request to Solr
+
+        :param path: the path to the collection
+        :type path: str
+        :param params: query params
+        :type params: dict
+        :returns response: an instance of :class:`~solrcloudpy.utils.SolrResponse`
+        :rtype: SolrResponse
+        :raise: SolrException
+        """
         return self.request(path, params, method='GET')
 
 
@@ -86,6 +141,12 @@ class CollectionBase(object):
     """
 
     def __init__(self, connection, name):
+        """
+        :param connection: the solr connection
+        :type connection: SolrConnection
+        :param name: the name of the collection
+        :type name: str
+        """
         self.connection = connection
         self.name = name
         self.client = _Request(connection)
@@ -139,6 +200,9 @@ class SolrResult(DictObject):
     def dict(self):
         """
         Convert this result into a python `dict` for easier manipulation
+        
+        :return: a dict
+        :rtype: dict
         """
         res = {}
         for (k, v) in self.__dict__.iteritems():
@@ -160,7 +224,8 @@ class SolrResponse(object):
         """
         Init this object.
 
-        :param response_object: the `Response` object from the `requests` package
+        :param response_obj: the `Response` object from the `requests` package
+        :type response_obj: requests.Response
         """
         # try to parse the content of this response as json
         # if that fails, try to save the text
@@ -175,10 +240,18 @@ class SolrResponse(object):
 
     @property
     def code(self):
-        """Status code of this response"""
+        """
+        Status code of this response
+        :return: http status code
+        :rtype: int
+        """
         return self._response_obj.status_code
 
     def __repr__(self):
+        """
+        :rtype: str
+        :return: representation in python
+        """
         return "<SolrResponse [%s]>" % self.code
 
 

--- a/test/README.md
+++ b/test/README.md
@@ -6,5 +6,12 @@ server, taken from the stock solr distribution.
 
 Running the tests
 ------------------
-First, modify where the solr jar can be found in
-`solr_instance.py`. Then run a test, ie `python test_collection`.
+You can run these tests by setting SOLR_HOME in your enviornment 
+as the path to where a solr executable jar lives. 
+`solr_instance.py` uses that information to create a connection to solr. 
+An example of in a test run would be 
+`SOLR_HOME=/home/dfdeshom/code/solr-4.6.0/example/solr python test_collection`,
+or you could export it.
+
+Without the solr collection, we won't perform any of the buildup and tear-down, but 
+will assume there is a Solr instance running at localhost:8983.

--- a/test/run
+++ b/test/run
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+# 
+# This is best used with Solr being started and stopped separately
+# But if you really want, you can still specify SOLR_HOME and it will apply to each one
+
+python solr_instance.py start
+echo "python test_collection.py" 
+SKIP_STARTUP=1 python test_collection.py
+echo "python test_connection.py"
+SKIP_STARTUP=1 python test_connection.py
+echo "python test_search.py"
+SKIP_STARTUP=1 python test_search.py
+python solr_instance.py stop

--- a/test/solr_instance.py
+++ b/test/solr_instance.py
@@ -1,35 +1,108 @@
 import subprocess
 import time
 import urllib
+import os
+import re
+
 
 class SolrInstance(object):
-    def __init__(self,name):
+    def __init__(self, name):
+        """
+        :param name: the name of the collection
+        :type name: str
+        """
+        
         self._process = None
         self.name = name
+        # e.g. /home/dfdeshom/code/solr-4.6.0/
+        self.solr_dir = os.getenv('SOLR_HOME', None)
+        if not self.solr_dir:
+            return
+        
+        self.solr_jar_dir = self.solr_dir + '/server'
+        self.zoo_data_2 = self.solr_dir + '/example/cloud/node1/solr/zoo_data/version-2/'
+        self.collection2_data = self.solr_dir + '/example/cloud/node2'
+        self.conf_dir = self.solr_jar_dir + '/solr/configsets/data_driven_schema_configs/conf'
+        
+        if self.solr_dir:
+            # find the solr version
+            with open(self.solr_dir+'/CHANGES.txt', 'r') as changes_file:
+                for line in changes_file:
+                    if '====' in line:
+                        matches = re.match(r'.*(\d+)\.(\d+)\.(\d+).*', line)
+                        self.solr_semver = map(lambda x: int(x), matches.groups())
+                        break
+                        
+            if self.solr_semver[0] == 4:
+                self.solr_jar_dir = self.solr_dir+'/example'
+                self.zoo_data_2 = self.solr_jar_dir + '/solr/zoo_data/version-2/'
+                self.collection2_data = self.solr_jar_dir + '/solr/coll2*'
+                self.conf_dir = self.solr_jar_dir+'/solr/collection1/conf'
 
     def start(self):
-        subprocess.Popen(['rm -rf /home/dfdeshom/code/solr-4.6.0/example/solr/zoo_data/version-2/'],shell=True)
-        subprocess.Popen(['rm -rf /home/dfdeshom/code/solr-4.6.0/example/solr/coll2*'],shell=True)
-
-        args = [
-        'java -Dcollection.configName=myconf -Dbootstrap_confdir=./solr/collection1/conf  -DzkRun -DnumShards=1 -jar start.jar>/dev/null',
-            ]
-
-        self._process = subprocess.Popen(args=args,
-                                         shell=True,
-                                         cwd='/home/dfdeshom/code/solr-4.6.0/example')
+        if self.solr_dir:
+            if self.solr_semver[0] == 4:
+                subprocess.Popen(['rm -rf %s' % self.zoo_data_2], shell=True)
+                subprocess.Popen(['rm -rf %s' % self.collection2_data], shell=True)
+                args = [' '.join([
+                    'java',
+                    '-Dcollection.configName=myconf',
+                    '-Dbootstrap_confdir=%s' % self.conf_dir,
+                    '-DzkRun',
+                    '-DnumShards=1',
+                    '-jar',
+                    'start.jar>/dev/null'
+                ])]
+                self._process = subprocess.Popen(args=args,
+                                                 shell=True,
+                                                 cwd=self.solr_jar_dir)
+            else:
+                args = ['./bin/solr start -e cloud -noprompt']
+                self._process = subprocess.Popen(args=args,
+                                                 shell=True,
+                                                 cwd=self.solr_dir)
 
     def wait_ready(self):
-        while True:
-            try:
-                res = urllib.urlopen("http://localhost:8983").read()
-                if res:
-                    return True
-            except:
-                time.sleep(1)
+        if not self._process or self.solr_semver[0] == 4:
+            sleeper = 0
+            while True:
+                try:
+                    res = urllib.urlopen("http://localhost:8983").read()
+                    if res:
+                        return True
+                except:
+                    time.sleep(1)
+                    sleeper += 1
+                    if sleeper > 15:
+                        raise Exception("Waited 15 seconds and no solr to be had -- please check your solr distro")
+        else:
+            self._process.wait()
+            return True
 
     def flush(self):
         pass
 
     def terminate(self):
-        subprocess.Popen(args=['killall -9 java'],shell=True)
+        if self.solr_dir:
+            if self.solr_semver[0] == 4:
+                # this is too damn broad
+                subprocess.Popen(args=['killall -9 java'], shell=True)
+            else:
+                args = ['./bin/solr stop -all']
+                self._process = subprocess.Popen(args=args,
+                                                 shell=True,
+                                                 cwd=self.solr_dir).wait()
+
+if __name__ == '__main__':
+    import sys
+    if sys.argv[1] == 'start':
+        print "Starting Solr"
+        instance = SolrInstance('solr2')
+        instance.start()
+        instance.wait_ready()
+        print "Started Solr"
+        sys.exit(0)
+    if sys.argv[1] == 'stop':
+        SolrInstance('solr2').terminate()
+        print "Terminated Solr"
+        sys.exit(0)

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -1,7 +1,11 @@
 import unittest
 from solr_instance import SolrInstance
 import time
+import os
 from solrcloudpy import SolrConnection, SolrCollection
+
+solrprocess = None
+
 
 class TestConnection(unittest.TestCase):
     def setUp(self):
@@ -9,11 +13,12 @@ class TestConnection(unittest.TestCase):
 
     def test_list(self):
         colls = self.conn.list()
-        self.assertTrue(len(colls)>=1)
+        self.assertTrue(len(colls) >= 1)
 
     def test_live_nodes(self):
         nodes = self.conn.live_nodes
-        self.assertTrue(len(nodes)==1)
+        # to support easy use of solrcloud gettingstarted
+        self.assertTrue(len(nodes) >= 1)
 
     def test_cluster_leader(self):
         leader = self.conn.cluster_leader
@@ -21,20 +26,26 @@ class TestConnection(unittest.TestCase):
 
     def test_create_collection(self):
         coll = self.conn.create_collection('test2')
-        self.assertTrue(isinstance(coll,SolrCollection))
+        self.assertTrue(isinstance(coll, SolrCollection))
         self.conn.test2.drop()
 
+
 def setUpModule():
+    if os.getenv('SKIP_STARTUP', False):
+        return
     # start solr
     solrprocess = SolrInstance("solr2")
     solrprocess.start()
     solrprocess.wait_ready()
     time.sleep(1)
 
+
 def tearDownModule():
-    # stop solr
-    import subprocess
-    subprocess.call(args=['killall -9 java'],shell=True)
+    if os.getenv('SKIP_STARTUP', False):
+        return
+    if solrprocess:
+        solrprocess.terminate()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_search.py
+++ b/test/test_search.py
@@ -1,7 +1,11 @@
 import unittest
 import time
+import os
 from solr_instance import SolrInstance
 from solrcloudpy import SolrConnection, SearchOptions
+
+
+solrprocess = None
 
 
 class TestCollectionSearch(unittest.TestCase):
@@ -43,6 +47,8 @@ class TestCollectionSearch(unittest.TestCase):
 
 
 def setUpModule():
+    if os.getenv('SKIP_STARTUP', False):
+        return
     # start solr
     solrprocess = SolrInstance("solr2")
     solrprocess.start()
@@ -51,9 +57,11 @@ def setUpModule():
 
 
 def tearDownModule():
-    # stop solr
-    import subprocess
-    subprocess.call(args=['killall -9 java'], shell=True)
+    if os.getenv('SKIP_STARTUP', False):
+        return
+    if solrprocess:
+        solrprocess.terminate()
+
 
 if __name__ == '__main__':
     # run tests


### PR DESCRIPTION
This backwards-compatible upgrade introduces support for
all stable versions of Solr 5.

It also makes several upgrades to style to conform to
PEP8 standards, and adds improvements to documentation
that should improve intelligent code completion in
projects implementing this library.

Finally, introduced additional test harnessing to allow
for testing against multiple versions of Solr without
code changes or advanced configuration.