### PR TITLE
Add support for incompatible versions of SolrCloud

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -12,7 +12,7 @@ The API is meant to be close to ``pymongo``'s API, where one can access collecti
 
 ::
 
-     >>> conn = SolrConnection(["localhost:9983","localhost:8984"])
+     >>> conn = SolrConnection(["localhost:9983","localhost:8984"], version='6.0.0')
      >>> conn.create('test1',num_shards=1,replication_factor=2)
      
      # Access an existing collection

--- a/solrcloudpy/__init__.py
+++ b/solrcloudpy/__init__.py
@@ -4,5 +4,5 @@ from solrcloudpy.parameters import SearchOptions
 import logging
 logging.basicConfig()
 
-__version__ = "1.8.1"
+__version__ = "2.0.0"
 __all__ = ['SolrCollection', 'SolrConnection', 'SearchOptions']

--- a/test/reset_state.py
+++ b/test/reset_state.py
@@ -1,6 +1,7 @@
 from solrcloudpy import SolrConnection
+import os
 
-connection = SolrConnection(['localhost:8983', 'localhost:7574'])
+connection = SolrConnection(['localhost:8983', 'localhost:7574'], version=os.getenv('SOLR_VERSION', '5.3.2'))
 for collection_name in connection.list():
     print "Dropping %s" % collection_name
     connection[collection_name].drop()

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -2,7 +2,7 @@ import unittest
 import time
 import os
 from solr_instance import SolrInstance
-from solrcloudpy import SolrConnection as Connection
+from solrcloudpy import SolrConnection
 from requests.adapters import ReadTimeout
 
 solrprocess = None
@@ -10,7 +10,7 @@ solrprocess = None
 
 class TestCollectionAdmin(unittest.TestCase):
     def setUp(self):
-        self.conn = Connection()
+        self.conn = SolrConnection(version=os.getenv('SOLR_VERSION', '5.3.2'))
 
     def test_create_collection(self):
         original_count = len(self.conn.list())

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -9,7 +9,7 @@ solrprocess = None
 
 class TestConnection(unittest.TestCase):
     def setUp(self):
-        self.conn = SolrConnection()
+        self.conn = SolrConnection(version=os.getenv('SOLR_VERSION', '5.3.2'))
 
     def test_list(self):
         self.conn['foo'].create()

--- a/test/test_search.py
+++ b/test/test_search.py
@@ -11,7 +11,7 @@ solrprocess = None
 class TestCollectionSearch(unittest.TestCase):
 
     def setUp(self):
-        self.conn = SolrConnection()
+        self.conn = SolrConnection(version=os.getenv('SOLR_VERSION', '5.3.2'))
 
     def test_add(self):
         coll2 = self.conn.create_collection('coll2')


### PR DESCRIPTION
SolrCloud 5.4+ has backwards-incompatible changes to the
Zookeeper APIs which were previously sorted out by exception
handling. This introduces latency to high-performance requests.

The current solution requires passing a version keyword argument to
the SolrConnection class's constructor. This version must be Semver-
compliant. Based on the version, we determine the correct Zookeeper
URL.

This has been tested against Solr 5.3.2 and Solr 6.0.0, which should
cover both paradigms.