### PR TITLE
Fixes to run tests against 6.1

### DIFF
--- a/solrcloudpy/connection.py
+++ b/solrcloudpy/connection.py
@@ -21,7 +21,7 @@ import solrcloudpy.collection as collection
 from solrcloudpy.utils import _Request
 
 MIN_SUPPORTED_VERSION = '>=4.6.0'
-MAX_SUPPORTED_VERSION = '<=6.0.0'
+MAX_SUPPORTED_VERSION = '<=6.1.0'
 
 
 class SolrConnection(object):

--- a/test/README.md
+++ b/test/README.md
@@ -15,3 +15,7 @@ or you could export it.
 
 Without the solr collection, we won't perform any of the buildup and tear-down, but 
 will assume there is a Solr instance running at localhost:8983.
+
+With recent versions of Solr, a configName argument is compulsory for creating
+collections, in which case, also set `SOLR_CONFNAME=myconfig` in the
+environment, assuming `myconfig` is already uploaded as a config to Solr.

--- a/test/test_connection.py
+++ b/test/test_connection.py
@@ -9,10 +9,14 @@ solrprocess = None
 
 class TestConnection(unittest.TestCase):
     def setUp(self):
-        self.conn = SolrConnection(version=os.getenv('SOLR_VERSION', '5.3.2'))
+        self.conn = SolrConnection(version=os.getenv('SOLR_VERSION', '6.1.0'))
+        self.collparams = {}
+        confname = os.getenv('SOLR_CONFNAME', '')
+        if confname != '':
+            self.collparams['collection_config_name'] = confname
 
     def test_list(self):
-        self.conn['foo'].create()
+        self.conn['foo'].create(**self.collparams)
         colls = self.conn.list()
         self.assertTrue(len(colls) >= 1)
         self.conn['foo'].drop()
@@ -27,7 +31,7 @@ class TestConnection(unittest.TestCase):
         self.assertTrue(leader is not None)
 
     def test_create_collection(self):
-        coll = self.conn.create_collection('test2')
+        coll = self.conn.create_collection('test2', **self.collparams)
         self.assertTrue(isinstance(coll, SolrCollection))
         self.conn.test2.drop()
 

--- a/test/test_search.py
+++ b/test/test_search.py
@@ -11,10 +11,14 @@ solrprocess = None
 class TestCollectionSearch(unittest.TestCase):
 
     def setUp(self):
-        self.conn = SolrConnection(version=os.getenv('SOLR_VERSION', '5.3.2'))
+        self.conn = SolrConnection(version=os.getenv('SOLR_VERSION', '6.1.0'))
+        self.collparams = {}
+        confname = os.getenv('SOLR_CONFNAME', '')
+        if confname != '':
+            self.collparams['collection_config_name'] = confname
 
     def test_add(self):
-        coll2 = self.conn.create_collection('coll2')
+        coll2 = self.conn.create_collection('coll2', **self.collparams)
         docs = [{"id": str(_id), "includes": "silly text"} for _id in range(5)]
 
         coll2.add(docs)
@@ -24,7 +28,7 @@ class TestCollectionSearch(unittest.TestCase):
         coll2.drop()
 
     def test_delete(self):
-        coll2 = self.conn.create_collection('coll2')
+        coll2 = self.conn.create_collection('coll2', **self.collparams)
         docs = [{"id": str(_id), "includes": "silly text"} for _id in range(5)]
 
         coll2.add(docs)


### PR DESCRIPTION
 - Allowing for configName to be specified in tests for creating new collections
 - Updating to 6.1 as the maximum supported version
 - Set the version used by tests by default to the newest version
