### PR TITLE
Add support for retries against the same server; bump version

### DIFF
--- a/solrcloudpy/__init__.py
+++ b/solrcloudpy/__init__.py
@@ -4,5 +4,5 @@ from solrcloudpy.parameters import SearchOptions
 import logging
 logging.basicConfig()
 
-__version__ = "2.1.0"
+__version__ = "2.2.0"
 __all__ = ['SolrCollection', 'SolrConnection', 'SearchOptions']

--- a/solrcloudpy/connection.py
+++ b/solrcloudpy/connection.py
@@ -21,7 +21,9 @@ import solrcloudpy.collection as collection
 from solrcloudpy.utils import _Request
 
 MIN_SUPPORTED_VERSION = '>=4.6.0'
-MAX_SUPPORTED_VERSION = '<=6.1.0'
+
+# TODO: revisit this when Solr 7 comes around.
+MAX_SUPPORTED_VERSION = '<=7.0.0'
 
 
 class SolrConnection(object):
@@ -44,6 +46,8 @@ class SolrConnection(object):
     :type webappdir: str
     :param version: the solr version we're currently running. defaults to 5.3.0 for backwards compatibility. must be semver compliant
     :type version: str
+    :param request_retries: number of times to retry a request against the same server. particularly useful for load-balancing or proxy situations.
+    :type request_retries: int
     """
 
     def __init__(self, server="localhost:8983",
@@ -52,12 +56,14 @@ class SolrConnection(object):
                  password=None,
                  timeout=10,
                  webappdir='solr',
-                 version='5.3.0'):
+                 version='5.3.0',
+                 request_retries=1):
         self.user = user
         self.password = password
         self.timeout = timeout
         self.webappdir = webappdir
         self.version = version
+        self.request_retries = request_retries
         
         if not semver.match(version, MIN_SUPPORTED_VERSION) and semver.match(version, MAX_SUPPORTED_VERSION):
             raise StandardError("Unsupported version %s" % version)


### PR DESCRIPTION
This is a backwards-compatible change that will allow us to specify the number of times we should retry the same server.

In some cases, we may want to use service discovery, a load balancer, or some other kind of proxy for all SolrCloud servers. In this case, we would only have one server to choose from in our settings. A failure to query one server may not be a definitive failure depending on how the proxy or load-balancer is instrumented.