### PR TITLE
Support python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,6 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Indexing/Search'
         ],
 
-    install_requires=['requests >= 2.11.1', 'IPython < 5.2.0', 'semver', 'pathlib2'],
+    install_requires=['requests >= 2.11.1', 'IPython < 5.2.0', 'semver', 'pathlib2', 'future'],
     extras_require={"ip": ['IPython == 5.1.0']}
 )

--- a/solrcloudpy/collection/search.py
+++ b/solrcloudpy/collection/search.py
@@ -4,6 +4,7 @@ Query and update a Solr collection
 
 from solrcloudpy.utils import CollectionBase, SolrException, as_json_bool
 
+from future.utils import iterkeys
 import datetime as dt
 import json
 
@@ -26,7 +27,7 @@ class SolrCollectionSearch(CollectionBase):
     def _get_response(self, path, params=None, method='GET', body=None):
         """
         Retrieves a response from the solr client
-        
+
         :param path: the URL of the solr endpoint
         :type path: str
         :param params: query params
@@ -119,7 +120,7 @@ class SolrCollectionSearch(CollectionBase):
         :rtype: SolrResponse
         :raise: SolrException
         """
-        if 'q' not in query.iterkeys():
+        if 'q' not in iterkeys(query):
             raise ValueError("query should have a 'q' parameter")
 
         if hasattr(query, 'commonparams'):
@@ -157,9 +158,9 @@ class SolrCollectionSearch(CollectionBase):
         return self._get_response('%s/update' % self.name, params=params).result
 
     def commit(self):
-        """ 
+        """
         Commit changes to a collection
-        
+
         :return: the solr response
         :rtype: SolrResponse
         :raise: SolrException

--- a/solrcloudpy/collection/stats.py
+++ b/solrcloudpy/collection/stats.py
@@ -1,6 +1,7 @@
 """
 Get different statistics about the underlying index in a collection
 """
+from future.utils import iteritems
 from solrcloudpy.utils import _Request, SolrResult
 
 
@@ -32,7 +33,7 @@ class SolrIndexStats(object):
         result = self.client.get('/solr/%s/admin/mbeans' % self.name, params).result.dict
         caches = result['solr-mbeans']['CACHE']
         res = {}
-        for cache, info in caches.iteritems():
+        for cache, info in iteritems(caches):
             if cache == 'fieldCache':
                 res[cache] = {'entries_count': info['stats'].get('entries_count', 0)}
                 continue
@@ -45,7 +46,7 @@ class SolrIndexStats(object):
     def queryhandler_stats(self):
         """
         Get query handler statistics for all of the handlers used in this Solr node
-        
+
         :return: The result
         :rtype: SolrResult
         """
@@ -53,7 +54,7 @@ class SolrIndexStats(object):
         result = self.client.get('/solr/%s/admin/mbeans' % self.name, params).result.dict
         caches = result['solr-mbeans']['QUERYHANDLER']
         res = {}
-        for cache, info in caches.iteritems():
+        for cache, info in iteritems(caches):
             res[cache] = info['stats']
 
         return SolrResult(res)

--- a/solrcloudpy/parameters.py
+++ b/solrcloudpy/parameters.py
@@ -1,3 +1,4 @@
+from future.utils import iterkeys, iteritems
 from collections import defaultdict
 
 
@@ -12,7 +13,7 @@ class BaseParams(object):
         if query:
             self._q['q'].add(query)
 
-        for k, v in kwargs.items():
+        for k, v in list(kwargs.items()):
             if hasattr(v, "__iter__"):
                 self._q[k].update(v)
             else:
@@ -24,7 +25,7 @@ class BaseParams(object):
         :return: self
         :rtype: BaseParams
         """
-        for k, v in kwargs.items():
+        for k, v in list(kwargs.items()):
             if hasattr(v, "__iter__"):
                 self._q[k].update(v)
             else:
@@ -51,7 +52,7 @@ class BaseParams(object):
         :rtype: iterable
         """
         c = self._q.copy()
-        return c.iteritems()
+        return iteritems(c)
 
     def __getitem__(self, item):
         """
@@ -67,7 +68,7 @@ class BaseParams(object):
         :return: an iterable
         :rtype: iterable
         """
-        return self._q.iterkeys()
+        return iterkeys(self._q)
 
     def __len__(self):
         """
@@ -204,7 +205,7 @@ class CommonParams(BaseParams):
     def debug(self):
         """
         Enables debugging for a particular query
-        
+
         :return: self for fluent interface
         :rtype: CommonParams
         """
@@ -508,7 +509,7 @@ class FacetParams(BaseParams):
         :param start: the starting offset
         :type start: int
         :param end: where the facet range ends
-        :type end: int 
+        :type end: int
         :param gap: the gap of each faceted range
         :type gap: int
         :return: self for fluent interface
@@ -580,12 +581,12 @@ class SearchOptions(object):
             res.update({'facet': 'true'})
         for p in self._all:
             res.update(iter(p))
-        return res.iteritems()
+        return iteritems(res)
 
     def iterkeys(self):
         res = []
         for p in self._all:
-            res += list(p.iterkeys())
+            res += list(iterkeys(p))
         return iter(res)
 
     def __repr__(self):

--- a/solrcloudpy/utils.py
+++ b/solrcloudpy/utils.py
@@ -127,6 +127,10 @@ class _Request(object):
                 if len(servers) <= 0:
                     logger.error('No servers left to try')
                     raise SolrException('No servers available')
+            finally:
+                # avoid requests library's keep alive throw exception in python3
+                if r is not None and r.connection:
+                    r.connection.close()
 
         return result
 

--- a/test/reset_state.py
+++ b/test/reset_state.py
@@ -1,7 +1,8 @@
+from __future__ import print_function
 from solrcloudpy import SolrConnection
 import os
 
 connection = SolrConnection(['localhost:8983', 'localhost:7574'], version=os.getenv('SOLR_VERSION', '5.3.2'))
 for collection_name in connection.list():
-    print "Dropping %s" % collection_name
+    print("Dropping %s" % collection_name)
     connection[collection_name].drop()

--- a/test/solr_instance.py
+++ b/test/solr_instance.py
@@ -1,6 +1,7 @@
+from __future__ import print_function
+from future.moves.urllib.request import urlopen
 import subprocess
 import time
-import urllib
 import os
 import re
 
@@ -11,28 +12,28 @@ class SolrInstance(object):
         :param name: the name of the collection
         :type name: str
         """
-        
+
         self._process = None
         self.name = name
         # e.g. /home/dfdeshom/code/solr-4.6.0/
         self.solr_dir = os.getenv('SOLR_HOME', None)
         if not self.solr_dir:
             return
-        
+
         self.solr_jar_dir = self.solr_dir + '/server'
         self.zoo_data_2 = self.solr_dir + '/example/cloud/node1/solr/zoo_data/version-2/'
         self.collection2_data = self.solr_dir + '/example/cloud/node2'
         self.conf_dir = self.solr_jar_dir + '/solr/configsets/data_driven_schema_configs/conf'
-        
+
         if self.solr_dir:
             # find the solr version
             with open(self.solr_dir+'/CHANGES.txt', 'r') as changes_file:
                 for line in changes_file:
                     if '====' in line:
                         matches = re.match(r'.*(\d+)\.(\d+)\.(\d+).*', line)
-                        self.solr_semver = map(lambda x: int(x), matches.groups())
+                        self.solr_semver = [int(x) for x in matches.groups()]
                         break
-                        
+
             if self.solr_semver[0] == 4:
                 self.solr_jar_dir = self.solr_dir+'/example'
                 self.zoo_data_2 = self.solr_jar_dir + '/solr/zoo_data/version-2/'
@@ -67,7 +68,7 @@ class SolrInstance(object):
             sleeper = 0
             while True:
                 try:
-                    res = urllib.urlopen("http://localhost:8983").read()
+                    res = urlopen("http://localhost:8983").read()
                     if res:
                         return True
                 except:
@@ -96,13 +97,13 @@ class SolrInstance(object):
 if __name__ == '__main__':
     import sys
     if sys.argv[1] == 'start':
-        print "Starting Solr"
+        print("Starting Solr")
         instance = SolrInstance('solr2')
         instance.start()
         instance.wait_ready()
-        print "Started Solr"
+        print("Started Solr")
         sys.exit(0)
     if sys.argv[1] == 'stop':
         SolrInstance('solr2').terminate()
-        print "Terminated Solr"
+        print("Terminated Solr")
         sys.exit(0)

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -80,7 +80,9 @@ class TestCollectionAdmin(unittest.TestCase):
             print("This generally doesn't mean the collection wasn't created with the settings passed.")
             coll2 = self.conn['test_delete_replica']
         time.sleep(3)
-        coll2.delete_replica('core_node2', 'myshard1')
+        firstReplica = list(coll2.shards['shards']['myshard1']['replicas'].dict.keys())[0]
+        result = coll2.delete_replica(firstReplica, 'myshard1')
+        self.assertTrue(result.success)
         coll2.drop()
 
 

--- a/test/test_collection.py
+++ b/test/test_collection.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import unittest
 import time
 import os
@@ -75,8 +76,8 @@ class TestCollectionAdmin(unittest.TestCase):
                                                 replication_factor=2,
                                                 **self.collparams)
         except ReadTimeout:
-            print "Encountered read timeout while testing delete replicate"
-            print "This generally doesn't mean the collection wasn't created with the settings passed."
+            print("Encountered read timeout while testing delete replicate")
+            print("This generally doesn't mean the collection wasn't created with the settings passed.")
             coll2 = self.conn['test_delete_replica']
         time.sleep(3)
         coll2.delete_replica('core_node2', 'myshard1')
@@ -90,8 +91,8 @@ def setUpModule():
     solrprocess.start()
     solrprocess.wait_ready()
     time.sleep(1)
-    
-    
+
+
 def tearDownModule():
     if os.getenv('SKIP_STARTUP', False):
         return

--- a/test/test_search.py
+++ b/test/test_search.py
@@ -52,11 +52,11 @@ class TestCollectionSearch(unittest.TestCase):
         docs = [{"id": str(_id), "includes": "silly text"} for _id in range(5)]
 
         res_1 = coll2.add(docs, {'omitHeader': "false"})
-        self.assertEquals(0, res_1.responseHeader.status)
+        self.assertEqual(0, res_1.responseHeader.status)
 
         coll2.commit()
         res_2 = coll2.search({"q": "id:1", "omitHeader": "false"}).result
-        self.assertEquals(0, res_2.responseHeader.status)
+        self.assertEqual(0, res_2.responseHeader.status)
 
 
 def setUpModule():


### PR DESCRIPTION
This PR should allow `solrcloudpy` to work with python 3, and yet still compatible with python 2.

Tested on `2.7.10` and `3.6.5` with the `test/run` script in this project.
